### PR TITLE
Improve env setup and error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # deckchatbot
 AI-powered chatbot for deck sales and quoting automation.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file in the project root with your OpenAI API key:
+   ```bash
+   cp .env.example .env
+   # then edit .env and set OPENAI_API_KEY
+   ```
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+The app will be available at `http://localhost:3000`.

--- a/index.html
+++ b/index.html
@@ -38,7 +38,10 @@
     });
 
     const data = await response.json();
-    const botMessage = data.response;
+    let botMessage = data.response;
+    if (!botMessage) {
+      botMessage = `Error: ${data.error || 'Unable to get response.'}`;
+    }
 
     messagesDiv.innerHTML += `<div><strong>Chatbot:</strong> ${botMessage}</div>`;
     messagesDiv.scrollTop = messagesDiv.scrollHeight;

--- a/server.cjs
+++ b/server.cjs
@@ -1,4 +1,8 @@
 require('dotenv').config();
+
+if (!process.env.OPENAI_API_KEY) {
+  console.warn('OPENAI_API_KEY is not set. Create a .env file with your key.');
+}
 const express = require('express');
 const multer = require('multer');
 const Tesseract = require('tesseract.js');


### PR DESCRIPTION
## Summary
- guide users to set `OPENAI_API_KEY`
- warn on missing env variable in the server
- show errors in the frontend instead of `undefined`
- add `.env.example` with placeholder key

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684a7ac128388332bd35b36b50fcc844