### PR TITLE
Improve OCR data handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,10 +66,15 @@
     if (data.error) {
       messagesDiv.innerHTML += `<div><strong>Chatbot:</strong> Error: ${data.error}</div>`;
     } else {
-      messagesDiv.innerHTML += `<div><strong>Chatbot:</strong> Outer Deck Area: ${data.outerDeckArea} sq ft<br>
+      let result = `<div><strong>Chatbot:</strong> Outer Deck Area: ${data.outerDeckArea} sq ft<br>
         Pool Area: ${data.poolArea} sq ft<br>
         Usable Deck Area: ${data.usableDeckArea} sq ft<br>
-        Railing Footage: ${data.railingFootage} ft</div>`;
+        Railing Footage: ${data.railingFootage} ft`;
+      if (data.warning) {
+        result += `<br><em>${data.warning}</em>`;
+      }
+      result += `</div>`;
+      messagesDiv.innerHTML += result;
     }
 
     messagesDiv.scrollTop = messagesDiv.scrollHeight;


### PR DESCRIPTION
## Summary
- strip inch/foot markers before parsing OCR numbers
- filter out canvas dimensions and split polygon points only when pool text is found
- warn when computed deck area exceeds 1000 sq ft
- display warning message in the web UI

## Testing
- `node -v`
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684a98117ec48332834f35d7ad3fae8f