### PR TITLE
Improve OCR extraction

### DIFF
--- a/tests/extractNumbers.test.js
+++ b/tests/extractNumbers.test.js
@@ -1,0 +1,23 @@
+jest.mock('openai', () => {
+  return jest.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: jest.fn().mockResolvedValue({ choices: [{ message: { content: 'mocked' } }] })
+      }
+    }
+  }));
+});
+
+const { extractNumbers } = require('../server.cjs');
+
+describe('extractNumbers', () => {
+  test('extracts numbers with units', () => {
+    const text = 'Deck sides: 10ft by 12ft';
+    expect(extractNumbers(text)).toEqual([10, 12]);
+  });
+
+  test('filters out huge misreads', () => {
+    const text = 'Size 611ft';
+    expect(extractNumbers(text)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit-aware OCR number parsing that filters massive misreads
- expose `extractNumbers` for testing
- add tests for `extractNumbers`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3f2d5c348332a5940caf6c22a04f