### PR TITLE
Add deck drawing digitalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,11 @@
   <br><br>
   <input type="file" id="imageInput" accept="image/*">
   <button id="uploadBtn" onclick="uploadImage()">Upload Image</button>
+  <br><br>
+  <input type="file" id="drawingInput" accept="image/*">
+  <button id="drawingBtn" onclick="uploadDrawing()">Upload Drawing</button>
+  <br>
+  <img id="digitalImage" style="max-width:100%; display:block; margin-top:10px;" />
 </div>
 
 <script>
@@ -79,6 +84,34 @@
 
     messagesDiv.scrollTop = messagesDiv.scrollHeight;
     fileInput.value = "";
+  }
+
+  async function uploadDrawing() {
+    const drawInput = document.getElementById("drawingInput");
+    const file = drawInput.files[0];
+    if (!file) {
+      alert("Please select a drawing to upload.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("image", file);
+
+    const response = await fetch("/digitalize-drawing", {
+      method: "POST",
+      body: formData
+    });
+
+    if (response.ok) {
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      document.getElementById("digitalImage").src = url;
+    } else {
+      const data = await response.json();
+      alert(data.error || "Error processing drawing.");
+    }
+
+    drawInput.value = "";
   }
 </script>
 

--- a/server.cjs
+++ b/server.cjs
@@ -5,6 +5,7 @@ const Tesseract = require('tesseract.js');
 const cors = require('cors');
 const path = require('path');
 const OpenAI = require('openai');
+const Jimp = require('jimp');
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY
@@ -191,6 +192,27 @@ app.post('/upload-measurements', upload.single('image'), async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Error processing image.' });
+  }
+});
+
+// Digitalize drawing endpoint
+app.post('/digitalize-drawing', upload.single('image'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'Please upload an image.' });
+    }
+    const img = await Jimp.read(req.file.buffer);
+    img
+      .greyscale()
+      .contrast(1)
+      .threshold({ max: 128 });
+
+    const buffer = await img.getBufferAsync(Jimp.MIME_PNG);
+    res.set('Content-Type', 'image/png');
+    res.send(buffer);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error processing drawing.' });
   }
 });
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -42,6 +42,12 @@ describe('server endpoints', () => {
     expect(res.body.error).toMatch(/Please upload an image/);
   });
 
+  test('/digitalize-drawing requires file', async () => {
+    const res = await request(app).post('/digitalize-drawing');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Please upload an image/);
+  });
+
   test('/chatbot', async () => {
     const res = await request(app).post('/chatbot').send({ message: 'hello' });
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- add Jimp dependency and endpoint to digitalize uploaded deck drawings
- update UI with new upload field and display for digitalized image
- include client-side code to call `/digitalize-drawing`
- test new endpoint for missing file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b4009c6d48332b9be9ddd6ea8065f