### PR TITLE
Improve deck area explanations

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,10 +71,13 @@
     if (data.error) {
       messagesDiv.innerHTML += `<div><strong>Chatbot:</strong> Error: ${data.error}</div>`;
     } else {
-      let result = `<div><strong>Chatbot:</strong> Outer Deck Area: ${data.outerDeckArea} sq ft<br>
-        Pool Area: ${data.poolArea} sq ft<br>
-        Usable Deck Area: ${data.usableDeckArea} sq ft<br>
+      let result = `<div><strong>Chatbot:</strong> Outer Area: ${data.outerDeckArea} sq ft<br>
+        Inner Cutout Area: ${data.poolArea} sq ft<br>
+        Final Usable Deck Area: ${data.usableDeckArea} sq ft<br>
         Railing Footage: ${data.railingFootage} ft`;
+      if (data.explanation) {
+        result += `<br>${data.explanation}`;
+      }
       if (data.warning) {
         result += `<br><em>${data.warning}</em>`;
       }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -40,13 +40,12 @@ describe('server endpoints', () => {
         wastagePercent: 10
       });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      totalShapeArea: '200.00',
-      poolArea: '78.54',
-      usableDeckArea: '121.46',
-      adjustedDeckArea: '133.61',
-      note: 'Adjusted for 10% wastage.'
-    });
+    expect(res.body.totalShapeArea).toBe('200.00');
+    expect(res.body.poolArea).toBe('78.54');
+    expect(res.body.usableDeckArea).toBe('121.46');
+    expect(res.body.adjustedDeckArea).toBe('133.61');
+    expect(res.body.note).toBe('Adjusted for 10% wastage.');
+    expect(res.body.explanation).toMatch(/composite deck/);
   });
 
   test('/upload-measurements requires file', async () => {
@@ -76,7 +75,8 @@ describe('server endpoints', () => {
     createMock.mockClear();
     const res = await request(app).post('/chatbot').send({ message: 'rectangle 5x10' });
     expect(res.status).toBe(200);
-    expect(res.body.response).toBe('The rectangle area is 50.00.');
+    expect(res.body.response).toContain('The rectangle area is 50.00.');
+    expect(res.body.response).toContain('simple deck with no cutouts');
     expect(createMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- explain net deck area in calculate-multi-shape and measurement OCR responses
- show cutout info when a single shape is parsed in the chatbot
- display new geometry labels in the UI
- update tests for new messaging

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b44e688008332b4087d0a3628d82b