### PR TITLE
Fix Flask dependency in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flash 
-openai 
+flask
+openai


### PR DESCRIPTION
## Summary
- replace typo `flash` with `flask`
- keep `openai` listed

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684bb003853083329ef29901248e83a9