### PR TITLE
Add drawing drag/drop UI and preview

### DIFF
--- a/controllers/digitalizeController.js
+++ b/controllers/digitalizeController.js
@@ -3,19 +3,13 @@ const path = require('path');
 const os = require('os');
 const Jimp = require('jimp');
 const potrace = require('potrace');
- codex/implement-security-enhancements-with-input-validation
-const { logger } = require('../server.cjs');
-const { validationResult } = require('express-validator');
-=======
 const logger = require('../utils/logger');
 const { cleanTempFile } = require('../utils/tmp-cleaner');
- main
 
 async function digitalizeDrawing(req, res) {
   try {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() });
+    if (!req.file) {
+      return res.status(400).json({ error: 'Please upload an image.' });
     }
     const img = await Jimp.read(req.file.buffer);
     img.greyscale().contrast(1).normalize().threshold({ max: 200 });

--- a/index.html
+++ b/index.html
@@ -25,10 +25,13 @@
       <input type="file" id="imageInput" accept="image/*" class="form-control d-inline w-auto">
       <button id="uploadBtn" type="button" onclick="uploadImage()" class="btn btn-primary ms-1">Upload Image</button>
     </div>
-    <div class="mt-3">
-      <input type="file" id="drawingInput" accept="image/*" class="form-control d-inline w-auto">
-      <button id="drawingBtn" type="button" onclick="uploadDrawing()" class="btn btn-primary ms-1">Upload Drawing</button>
+    <div class="mt-3" id="drawingArea">
+      <input type="file" id="drawingInput" accept="image/*" class="d-none">
+      <div id="drawingDropZone" class="drop-zone">Drop drawing here or click to select</div>
+      <img id="drawingPreview" alt="Drawing preview" class="img-fluid mt-2" style="display:none;">
+      <button id="drawingBtn" type="button" onclick="uploadDrawing()" class="btn btn-primary mt-2">Upload Drawing</button>
     </div>
+    <div id="processing" class="mt-2 text-center" style="display:none;">Processing...</div>
     <div id="digitalWrapper" class="mt-4 text-center">
       <h3>Digitalized Drawing</h3>
       <img id="digitalImage" alt="Digitalized drawing" class="img-fluid">

--- a/routes/digitalize.js
+++ b/routes/digitalize.js
@@ -1,18 +1,9 @@
 const express = require('express');
 const multer = require('multer');
-const { body } = require('express-validator');
 const { digitalizeDrawing } = require('../controllers/digitalizeController');
 
 const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
-const validate = [
-  body('image').custom((_, { req }) => {
-    if (!req.file) {
-      throw new Error('Image file is required');
-    }
-    return true;
-  })
-];
-router.post('/', upload.single('image'), validate, digitalizeDrawing);
+router.post('/', upload.single('image'), digitalizeDrawing);
 
 module.exports = router;

--- a/script.js
+++ b/script.js
@@ -73,30 +73,39 @@ async function uploadImage() {
 
 async function uploadDrawing() {
   const drawInput = document.getElementById('drawingInput');
+  const preview = document.getElementById('drawingPreview');
+  const processing = document.getElementById('processing');
   const file = drawInput.files[0];
   if (!file) {
     alert('Please select a drawing to upload.');
     return;
   }
 
+  processing.style.display = 'block';
   const formData = new FormData();
   formData.append('image', file);
 
-  const response = await fetch('/digitalize-drawing', {
-    method: 'POST',
-    body: formData
-  });
+  try {
+    const response = await fetch('/digitalize-drawing', {
+      method: 'POST',
+      body: formData
+    });
 
-  if (response.ok) {
-    const blob = await response.blob();
-    const url = URL.createObjectURL(blob);
-    document.getElementById('digitalImage').src = url;
-  } else {
-    const data = await response.json();
-    alert(data.error || 'Error processing drawing.');
+    if (response.ok) {
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      document.getElementById('digitalImage').src = url;
+    } else {
+      const data = await response.json();
+      alert(data.error || 'Error processing drawing.');
+    }
+  } catch (err) {
+    alert('Error processing drawing.');
+  } finally {
+    processing.style.display = 'none';
+    drawInput.value = '';
+    preview.style.display = 'none';
   }
-
-  drawInput.value = '';
 }
 
 function toggleTheme() {
@@ -111,4 +120,31 @@ document.getElementById('themeToggle').addEventListener('click', toggleTheme);
 window.addEventListener('DOMContentLoaded', () => {
   const saved = localStorage.getItem('theme') || 'light';
   document.body.setAttribute('data-theme', saved);
+
+  const dropZone = document.getElementById('drawingDropZone');
+  const drawInput = document.getElementById('drawingInput');
+  const preview = document.getElementById('drawingPreview');
+
+  function showPreview(file) {
+    if (!file) return;
+    preview.src = URL.createObjectURL(file);
+    preview.style.display = 'block';
+  }
+
+  dropZone.addEventListener('click', () => drawInput.click());
+  dropZone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+  });
+  dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+  dropZone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+    if (e.dataTransfer.files[0]) {
+      drawInput.files = e.dataTransfer.files;
+      showPreview(e.dataTransfer.files[0]);
+    }
+  });
+
+  drawInput.addEventListener('change', () => showPreview(drawInput.files[0]));
 });

--- a/style.css
+++ b/style.css
@@ -69,3 +69,15 @@ body {
   from { opacity: 0; transform: translateY(5px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+.drop-zone {
+  border: 2px dashed var(--border-color);
+  padding: 20px;
+  text-align: center;
+  cursor: pointer;
+  color: var(--text-color);
+}
+
+.drop-zone.dragover {
+  background: rgba(0, 0, 0, 0.05);
+}


### PR DESCRIPTION
## Summary
- add drag-and-drop UI for drawing uploads
- preview drawings before uploading and show processing status
- simplify digitalize route & controller to keep previous validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ced30d84c8332abe813067ffbc175

## Summary by Sourcery

Introduce a drag-and-drop interface with live preview and processing indicator for drawing uploads, and streamline the digitalize drawing endpoint by removing express-validator and consolidating file validation.

New Features:
- Add a drag-and-drop zone for drawing uploads with click-to-select fallback
- Display a live preview of the selected drawing before upload
- Show a processing indicator during the digitalization request

Enhancements:
- Simplify the /digitalize-drawing route by removing express-validator middleware
- Consolidate file validation in the controller with manual checks and return JSON errors
- Wrap the client-side fetch call in try/catch/finally to improve error handling and cleanup
- Automatically reset the drawing input and hide the preview after upload completion