### PR TITLE
Fix Jimp import to enable uploads

### DIFF
--- a/__tests__/measurements.test.js
+++ b/__tests__/measurements.test.js
@@ -23,7 +23,7 @@ jest.mock('jimp', () => {
     getBuffer: jest.fn((type, cb) => cb(null, Buffer.from('img')))
   };
   const readMock = jest.fn(() => Promise.resolve(mockImage));
-  return { read: readMock, __mockImage: mockImage, __readMock: readMock };
+  return { Jimp: { read: readMock }, __mockImage: mockImage, __readMock: readMock };
 });
 
 jest.mock('potrace', () => ({

--- a/controllers/digitalizeController.js
+++ b/controllers/digitalizeController.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const Jimp = require('jimp');
+const { Jimp } = require('jimp');
 const potrace = require('potrace');
 const logger = require('../utils/logger');
 const { cleanTempFile } = require('../utils/tmp-cleaner');


### PR DESCRIPTION
## Summary
- fix digital drawing conversion by importing `Jimp` correctly
- update tests to match new Jimp import pattern

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cef489bac8332856fc9ef73d5c499

## Summary by Sourcery

Fix the Jimp import to use named destructuring and update related tests to match the new import pattern

Bug Fixes:
- Correct Jimp import in digitalizeController to destructure the Jimp object

Tests:
- Adjust Jimp mock in measurements tests to return a nested Jimp object matching the updated import