### PR TITLE
Validate OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This project provides a simple Express server with a chatbot interface for deck 
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+2. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`. The server will
+   fail to start if this variable is not provided.
 3. Start the server:
    ```bash
    npm start

--- a/config/index.js
+++ b/config/index.js
@@ -1,7 +1,15 @@
 require('dotenv').config();
 
+const PORT = process.env.PORT || 3000;
+const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
+const { OPENAI_API_KEY } = process.env;
+
+if (!OPENAI_API_KEY && process.env.NODE_ENV !== 'test') {
+  throw new Error('OPENAI_API_KEY environment variable is required');
+}
+
 module.exports = {
-  PORT: process.env.PORT || 3000,
-  LOG_LEVEL: process.env.LOG_LEVEL || 'info',
-  OPENAI_API_KEY: process.env.OPENAI_API_KEY || ''
+  PORT,
+  LOG_LEVEL,
+  OPENAI_API_KEY: OPENAI_API_KEY || ''
 };


### PR DESCRIPTION
## Summary
- fail fast when `OPENAI_API_KEY` is missing
- document the required variable in the setup instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cfe610a088332a91d6ba9189b47a6

## Summary by Sourcery

Validate the presence of OPENAI_API_KEY at startup and update setup documentation accordingly

Enhancements:
- Fail fast by throwing an error when OPENAI_API_KEY is not set in non-test environments
- Centralise and destructure PORT and LOG_LEVEL configuration variables

Documentation:
- Clarify in README that the server will fail to start if OPENAI_API_KEY is missing