### PR TITLE
Add upload file validation

### DIFF
--- a/__tests__/measurements.test.js
+++ b/__tests__/measurements.test.js
@@ -73,6 +73,23 @@ describe('server edge cases', () => {
     expect(res.body.error).toMatch(/Unsupported shape type/);
   });
 
+  test('/upload-measurements rejects non-image', async () => {
+    const res = await request(app)
+      .post('/upload-measurements')
+      .attach('image', Buffer.from('text'), 'file.txt');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Only image files/);
+  });
+
+  test('/upload-measurements rejects large file', async () => {
+    const big = Buffer.alloc(6 * 1024 * 1024);
+    const res = await request(app)
+      .post('/upload-measurements')
+      .attach('image', big, 'big.png');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/File too large/);
+  });
+
   test('/upload-measurements not enough numbers', async () => {
     recognizeMock.mockResolvedValue({ data: { text: '1 2 3 4' } });
     const res = await request(app)


### PR DESCRIPTION
## Summary
- validate measurement upload images with a Multer file filter
- restrict upload size to 5MB
- handle Multer errors in the route
- test that invalid types and oversized files fail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cfe8ea1b0833287b6e39345775e20