### PR TITLE
Add message history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deck Chatbot
 
-This project provides a simple Express server with a chatbot interface for deck sales and quoting automation. It includes endpoints for calculating deck measurements and uploading images.
+This project provides a simple Express server with a chatbot interface for deck sales and quoting automation. It includes endpoints for calculating deck measurements and uploading images. A `/chatbot/history` endpoint is also available to view recent conversation logs.
 
 ## Setup
 1. Install dependencies:

--- a/__tests__/chatbot.test.js
+++ b/__tests__/chatbot.test.js
@@ -73,6 +73,14 @@ describe('server endpoints', () => {
     ]);
   });
 
+  test('/chatbot/history returns messages', async () => {
+    await request(app).post('/chatbot').send({ message: 'hi' });
+    const res = await request(app).get('/chatbot/history');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.history)).toBe(true);
+    expect(res.body.history.length).toBeGreaterThan(0);
+  });
+
   test('/chatbot handles rectangle', async () => {
     createMock.mockClear();
     const res = await request(app).post('/chatbot').send({ message: 'rectangle 5x10' });

--- a/controllers/chatbotController.js
+++ b/controllers/chatbotController.js
@@ -66,4 +66,15 @@ async function chatbot(req, res, next) {
   }
 }
 
-module.exports = { chatbot, validate };
+function getHistory(req, res) {
+  const limit = parseInt(req.query.limit, 10) || 10;
+  try {
+    const history = getRecentMessages(limit);
+    res.json({ history });
+  } catch (err) {
+    logger.error(err.stack);
+    res.status(500).json({ error: 'Failed to fetch message history.' });
+  }
+}
+
+module.exports = { chatbot, validate, getHistory };

--- a/routes/chatbot.js
+++ b/routes/chatbot.js
@@ -1,7 +1,8 @@
 const express = require('express');
-const { chatbot, validate } = require('../controllers/chatbotController');
+const { chatbot, validate, getHistory } = require('../controllers/chatbotController');
 
 const router = express.Router();
 router.post('/', validate, chatbot);
+router.get('/history', getHistory);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose new GET `/chatbot/history` route
- implement controller method to fetch recent messages
- document endpoint
- test history endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cfe9d4f4483328a3cb20191f78e85

## Summary by Sourcery

Expose a new GET `/chatbot/history` endpoint to retrieve recent chatbot messages.

New Features:
- Add GET `/chatbot/history` route with an optional `limit` query parameter to fetch recent messages.

Documentation:
- Update README to document the new `/chatbot/history` endpoint.

Tests:
- Add integration test to verify the `/chatbot/history` endpoint returns a non-empty message array.