### PR TITLE
Add tests for OpenAI service and digitalize error

### DIFF
--- a/__tests__/measurements.test.js
+++ b/__tests__/measurements.test.js
@@ -120,6 +120,15 @@ describe('server edge cases', () => {
     expect(res.body.error).toMatch(/Error digitalizing drawing/);
   });
 
+  test('/digitalize-drawing handles image read failure', async () => {
+    readMock.mockImplementationOnce(() => Promise.reject(new Error('read fail')));
+    const res = await request(app)
+      .post('/digitalize-drawing')
+      .attach('image', Buffer.from('img'), 'draw.png');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/Error processing drawing/);
+  });
+
   test('/chatbot requires message', async () => {
     const res = await request(app).post('/chatbot').send({});
     expect(res.status).toBe(400);

--- a/__tests__/openai.service.test.js
+++ b/__tests__/openai.service.test.js
@@ -1,0 +1,24 @@
+jest.mock('openai', () => {
+  const createMock = jest.fn();
+  const MockOpenAI = jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: createMock } }
+  }));
+  MockOpenAI.__createMock = createMock;
+  return MockOpenAI;
+});
+
+const OpenAI = require('openai');
+const createMock = OpenAI.__createMock;
+const { askChat } = require('../services/openai.service');
+
+describe('askChat', () => {
+  test('returns message content on success', async () => {
+    createMock.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] });
+    await expect(askChat([{ role: 'user', content: 'hi' }])).resolves.toBe('ok');
+  });
+
+  test('propagates API errors', async () => {
+    createMock.mockRejectedValueOnce(new Error('fail'));
+    await expect(askChat([{ role: 'user', content: 'hi' }])).rejects.toThrow('fail');
+  });
+});


### PR DESCRIPTION
## Summary
- add test for digitalizeDrawing when Jimp fails to read
- create unit tests for openai.service async behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684cfeb3dfe083328de89b1ec15de3cc

## Summary by Sourcery

Add tests to cover digitalize drawing error handling and OpenAI service async behavior

Tests:
- Add test for /digitalize-drawing endpoint to handle image read failure
- Add unit tests for askChat in openai.service to validate successful response and error propagation