### PR TITLE
Improve theme detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -118,7 +118,10 @@ function toggleTheme() {
 document.getElementById('themeToggle').addEventListener('click', toggleTheme);
 
 window.addEventListener('DOMContentLoaded', () => {
-  const saved = localStorage.getItem('theme') || 'light';
+  let saved = localStorage.getItem('theme');
+  if (!saved) {
+    saved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
   document.body.setAttribute('data-theme', saved);
 
   const dropZone = document.getElementById('drawingDropZone');

--- a/style.css
+++ b/style.css
@@ -7,6 +7,17 @@
   --message-bot-bg: #f1f1f1;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #000000;
+    --text-color: #eeeeee;
+    --chat-bg: #222222;
+    --border-color: #444444;
+    --message-user-bg: #4a90e2;
+    --message-bot-bg: #444444;
+  }
+}
+
 body[data-theme='dark'] {
   --bg-color: #000000;
   --text-color: #eeeeee;


### PR DESCRIPTION
## Summary
- pick theme from user's system preference by default
- keep theme toggle button override

## Testing
- `npm test` *(fails: unexpected token in config)*

------
https://chatgpt.com/codex/tasks/task_e_684d029124d4833285485c4269dbcb22