### PR TITLE
Add timestamps to chat messages

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,20 @@
 function appendMessage(role, text) {
   const div = document.createElement('div');
   div.className = `message ${role}`;
-  div.textContent = text;
+
+  const textSpan = document.createElement('span');
+  textSpan.className = 'message-text';
+  textSpan.textContent = text;
+
+  const timeSpan = document.createElement('span');
+  timeSpan.className = 'timestamp';
+  timeSpan.textContent = new Date().toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+  div.appendChild(textSpan);
+  div.appendChild(timeSpan);
   document.getElementById('messages').appendChild(div);
 }
 

--- a/style.css
+++ b/style.css
@@ -50,6 +50,13 @@ body {
   animation: fadeIn 0.3s ease-in-out;
 }
 
+.message .timestamp {
+  display: block;
+  font-size: 0.75em;
+  color: #555;
+  margin-top: 2px;
+}
+
 .message.user {
   background: var(--message-user-bg);
   text-align: right;


### PR DESCRIPTION
## Summary
- show timestamp for each message
- style timestamps with smaller font

## Testing
- `npm test` *(fails: SyntaxError in config)*

------
https://chatgpt.com/codex/tasks/task_e_684d02e42fb48332b7693305d7d257c7

## Summary by Sourcery

Add timestamps to chat messages and update styling to display them clearly

New Features:
- Display a timestamp with each chat message

Enhancements:
- Render timestamps in a smaller, muted font below each message