### PR TITLE
Improve layout responsiveness

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -9,15 +9,9 @@ if (!OPENAI_API_KEY && process.env.NODE_ENV !== 'test') {
 }
 
 module.exports = {
- codex/add-rate-limiting-middleware
-  PORT: process.env.PORT || 3000,
-  LOG_LEVEL: process.env.LOG_LEVEL || 'info',
-  OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
-  RATE_LIMIT_WINDOW_MS: parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 15 * 60 * 1000,
-  RATE_LIMIT_MAX: parseInt(process.env.RATE_LIMIT_MAX, 10) || 100
-=======
   PORT,
   LOG_LEVEL,
-  OPENAI_API_KEY: OPENAI_API_KEY || ''
- main
+  OPENAI_API_KEY: OPENAI_API_KEY || '',
+  RATE_LIMIT_WINDOW_MS: parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 15 * 60 * 1000,
+  RATE_LIMIT_MAX: parseInt(process.env.RATE_LIMIT_MAX, 10) || 100
 };

--- a/controllers/chatbotController.js
+++ b/controllers/chatbotController.js
@@ -66,10 +66,10 @@ async function chatbot(req, res, next) {
   }
 }
 
-function getHistory(req, res) {
+async function getHistory(req, res) {
   const limit = parseInt(req.query.limit, 10) || 10;
   try {
-    const history = getRecentMessages(limit);
+    const history = await getRecentMessages(limit);
     res.json({ history });
   } catch (err) {
     logger.error(err.stack);

--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
     <button id="themeToggle" class="btn btn-secondary btn-sm">Toggle Theme</button>
   </div>
   <p class="note">To analyze deck drawings, select an image file and click <strong>Upload Image</strong>. Uploading images does not work through this text chat.</p>
-  <div id="chat">
+  <div id="chatContainer">
+    <div id="chat">
     <h2>Decking Chatbot</h2>
     <div id="messages"></div>
     <form id="chatForm" autocomplete="off">
@@ -32,11 +33,12 @@
       <button id="drawingBtn" type="button" onclick="uploadDrawing()" class="btn btn-primary mt-2">Upload Drawing</button>
     </div>
     <div id="processing" class="mt-2 text-center" style="display:none;">Processing...</div>
+    </div><!-- end chat -->
     <div id="digitalWrapper" class="mt-4 text-center">
       <h3>Digitalized Drawing</h3>
       <img id="digitalImage" alt="Digitalized drawing" class="img-fluid">
     </div>
-  </div>
+  </div><!-- end chatContainer -->
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -34,6 +34,11 @@ body {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
+#chatContainer {
+  max-width: 1200px;
+  margin: auto;
+}
+
 #messages {
   border: 1px solid var(--border-color);
   padding: 10px;
@@ -61,8 +66,26 @@ body {
 }
 
 #digitalWrapper {
-  max-width: 600px;
+  width: 100%;
   margin: 20px auto;
+}
+
+@media (min-width: 900px) {
+  #chatContainer {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+  }
+  #chat {
+    flex: 1 1 60%;
+    max-width: 700px;
+    margin: 0;
+  }
+  #digitalWrapper {
+    flex: 1 1 40%;
+    margin: 0;
+    max-width: none;
+  }
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- wrap chat UI in new `#chatContainer`
- show digitalized drawing beside chat on wide screens
- add responsive flex styles
- fix history endpoint and restore clean config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d03370bcc8332b1f58e61808faee4