### PR TITLE
Improve mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,3 +141,29 @@ input:focus,
   white-space: nowrap;
   border: 0;
 }
+
+/* Layout tweaks for message input */
+#inputArea {
+  display: flex;
+  align-items: center;
+}
+
+#inputArea .form-control {
+  flex: 1;
+}
+
+@media (max-width: 600px) {
+  #messages {
+    height: 40vh;
+  }
+
+  #inputArea {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  #inputArea .form-control {
+    margin-right: 0 !important;
+    margin-bottom: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- adjust chat interface styles for smaller screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d106d1b148332813459fa03c2b0b4

## Summary by Sourcery

Improve chat interface layout on mobile by applying flexbox to the input area and adding responsive adjustments for smaller screens

Enhancements:
- Use flex layout for #inputArea and allow form-control to grow to fill available space
- Limit #messages height to 40vh and stack input controls with adjusted margins on screens narrower than 600px