### PR TITLE
Add drawing upload route and frontend page

### DIFF
--- a/controllers/drawingUploadController.js
+++ b/controllers/drawingUploadController.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('../utils/db');
+const logger = require('../utils/logger');
+
+async function uploadDrawing(req, res) {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'Please upload an image' });
+    }
+
+    const uploadDir = path.join(__dirname, '../public/uploads');
+    await fs.promises.mkdir(uploadDir, { recursive: true });
+
+    const filename = `${Date.now()}-${req.file.originalname}`;
+    const filePath = path.join(uploadDir, filename);
+    await fs.promises.writeFile(filePath, req.file.buffer);
+
+    // store metadata
+    db.run(
+      'INSERT INTO upload_history (file_name, file_type) VALUES (?, ?)',
+      [filename, req.file.mimetype]
+    );
+
+    const publicPath = `/uploads/${filename}`;
+    res.json({ status: 'success', filePath: publicPath });
+  } catch (err) {
+    logger.error(`Error uploading drawing: ${err.stack}`);
+    res.status(500).json({ error: 'Error saving image' });
+  }
+}
+
+module.exports = { uploadDrawing };

--- a/routes/uploadDrawing.js
+++ b/routes/uploadDrawing.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const multer = require('multer');
+const { uploadDrawing } = require('../controllers/drawingUploadController');
+
+const router = express.Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+router.post('/', upload.single('image'), uploadDrawing);
+
+module.exports = router;

--- a/server.cjs
+++ b/server.cjs
@@ -14,6 +14,7 @@ const chatbotRoutes = require('./routes/chatbot');
 const digitalizeController = require('./controllers/digitalizeController');
 const measurementRoutes = require('./routes/measurements');
 const shapeController = require('./controllers/shapeController'); // ✅ NEW
+const uploadDrawingRoutes = require('./routes/uploadDrawing');
 
 const app = express();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -35,6 +36,8 @@ app.post(
   digitalizeController.digitalizeDrawing
 );
 
+app.use('/upload-drawing', upload.single('image'), uploadDrawingRoutes);
+
 app.use(
   '/upload-measurements',
   upload.single('image'),
@@ -47,8 +50,9 @@ app.post(
   shapeController.calculateMultiShape
 );
 
-// Serve frontend files
+// Serve frontend files and uploads
 app.use(express.static(path.join(__dirname)));
+app.use('/uploads', express.static(path.join(__dirname, 'public', 'uploads')));
 
 // 404 handler
 app.use((req, res) => {

--- a/upload.html
+++ b/upload.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Upload Drawing</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    #dropZone {
+      border: 2px dashed #ccc;
+      padding: 40px;
+      text-align: center;
+      cursor: pointer;
+      margin-bottom: 1rem;
+    }
+    #dropZone.dragover {
+      background-color: #f0f8ff;
+    }
+    #preview {
+      max-width: 100%;
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container mt-4">
+    <h2 class="mb-3">Upload Drawing</h2>
+    <div id="dropZone" class="mb-3">Drag & drop image here or click to select</div>
+    <input type="file" id="fileInput" accept="image/*" class="d-none" />
+    <img id="preview" class="d-none" alt="preview" />
+    <div class="mt-2">
+      <button id="uploadButton" class="btn btn-primary">Upload</button>
+      <div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
+    </div>
+  </div>
+  <script src="upload.js"></script>
+</body>
+</html>

--- a/upload.js
+++ b/upload.js
@@ -1,0 +1,56 @@
+const dropZone = document.getElementById('dropZone');
+const fileInput = document.getElementById('fileInput');
+const preview = document.getElementById('preview');
+const spinner = document.getElementById('spinner');
+
+function handleFiles(files) {
+  const file = files[0];
+  if (!file) return;
+  fileInput.files = files;
+  const reader = new FileReader();
+  reader.onload = e => {
+    preview.src = e.target.result;
+    preview.classList.remove('d-none');
+  };
+  reader.readAsDataURL(file);
+}
+
+dropZone.addEventListener('click', () => fileInput.click());
+dropZone.addEventListener('dragover', e => {
+  e.preventDefault();
+  dropZone.classList.add('dragover');
+});
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+dropZone.addEventListener('drop', e => {
+  e.preventDefault();
+  dropZone.classList.remove('dragover');
+  handleFiles(e.dataTransfer.files);
+});
+
+fileInput.addEventListener('change', e => handleFiles(e.target.files));
+
+document.getElementById('uploadButton').addEventListener('click', async () => {
+  const file = fileInput.files[0];
+  if (!file) {
+    alert('Please select an image');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('image', file);
+
+  spinner.classList.remove('d-none');
+  try {
+    const res = await fetch('/upload-drawing', { method: 'POST', body: formData });
+    const data = await res.json();
+    spinner.classList.add('d-none');
+    if (res.ok) {
+      alert('Uploaded to ' + data.filePath);
+    } else {
+      alert(data.error || 'Upload failed');
+    }
+  } catch (err) {
+    spinner.classList.add('d-none');
+    alert(err.message || 'Upload failed');
+  }
+});


### PR DESCRIPTION
## Summary
- create a dedicated controller for saving uploaded images
- expose `/upload-drawing` route
- serve uploaded files from `/uploads`
- add simple upload page with drag/drop and preview
- add client script handling drag-and-drop preview and POST request

## Testing
- `npm test` *(fails: /upload-measurements tests expect status 400 but received 500)*

------
https://chatgpt.com/codex/tasks/task_e_684d19f2149c83329c96686eb3e75571