### PR TITLE
Add deck layout calculator with canvas visualization

### DIFF
--- a/controllers/deckCalcController.js
+++ b/controllers/deckCalcController.js
@@ -1,0 +1,27 @@
+function calculateDeckMaterials(req, res) {
+  const {
+    length,
+    width,
+    boardWidth = 5.5,
+    boardLength = 16,
+    waste = 10
+  } = req.body;
+
+  if (!length || !width) {
+    return res.status(400).json({
+      errors: [{ msg: 'length and width are required' }]
+    });
+  }
+
+  const deckArea = length * width;
+  const boardArea = (boardWidth / 12) * boardLength;
+  const boards = Math.ceil((deckArea / boardArea) * (1 + waste / 100));
+
+  res.json({
+    deckArea: deckArea.toFixed(2),
+    boardArea: boardArea.toFixed(2),
+    boards
+  });
+}
+
+module.exports = { calculateDeckMaterials };

--- a/index.html
+++ b/index.html
@@ -72,6 +72,50 @@
       <h3>Digitalized Drawing</h3>
       <img id="digitalImage" alt="Digitalized drawing" class="img-fluid" />
     </div>
+
+    <!-- Deck Calculator -->
+    <div id="deckCalc" class="mt-5">
+      <h3>Deck Layout & Material Calculator</h3>
+      <form id="deckForm" class="row gy-2 gx-3 align-items-center">
+        <div class="col-auto">
+          <label class="visually-hidden" for="shape">Shape</label>
+          <select id="shape" class="form-select">
+            <option value="rectangle" selected>Rectangle</option>
+          </select>
+        </div>
+        <div class="col-auto">
+          <label class="visually-hidden" for="length">Length (ft)</label>
+          <input type="number" min="1" step="0.1" id="length" class="form-control" placeholder="Length (ft)" required />
+        </div>
+        <div class="col-auto">
+          <label class="visually-hidden" for="width">Width (ft)</label>
+          <input type="number" min="1" step="0.1" id="width" class="form-control" placeholder="Width (ft)" required />
+        </div>
+        <div class="col-auto">
+          <label class="visually-hidden" for="boardWidth">Board Width (in)</label>
+          <input type="number" min="1" step="0.1" id="boardWidth" class="form-control" value="5.5" />
+        </div>
+        <div class="col-auto">
+          <label class="visually-hidden" for="boardLength">Board Length (ft)</label>
+          <input type="number" min="1" step="0.1" id="boardLength" class="form-control" value="16" />
+        </div>
+        <div class="col-auto">
+          <label class="visually-hidden" for="waste">Waste %</label>
+          <input type="number" min="0" step="1" id="waste" class="form-control" value="10" />
+        </div>
+        <div class="col-auto">
+          <button type="submit" class="btn btn-success">Calculate</button>
+        </div>
+        <div class="col-auto">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="showBoards" checked />
+            <label class="form-check-label" for="showBoards">Show Boards</label>
+          </div>
+        </div>
+      </form>
+      <canvas id="deckCanvas" width="400" height="300" class="border mt-3"></canvas>
+      <div id="calcResults" class="mt-3"></div>
+    </div>
   </div>
 
   <script src="script.js"></script>

--- a/routes/deckCalc.js
+++ b/routes/deckCalc.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { calculateDeckMaterials } = require('../controllers/deckCalcController');
+
+const router = express.Router();
+
+router.post('/', calculateDeckMaterials);
+
+module.exports = router;

--- a/script.js
+++ b/script.js
@@ -119,4 +119,96 @@ document.getElementById('themeToggle').addEventListener('click', toggleTheme);
 window.addEventListener('DOMContentLoaded', () => {
   const saved = localStorage.getItem('theme') || 'light';
   document.body.setAttribute('data-theme', saved);
+
+  const deckForm = document.getElementById('deckForm');
+  if (deckForm) {
+    deckForm.addEventListener('submit', e => {
+      e.preventDefault();
+      calculateDeck();
+    });
+  }
+
+  const showBoards = document.getElementById('showBoards');
+  if (showBoards) {
+    showBoards.addEventListener('change', () => calculateDeck());
+  }
 });
+
+function calculateDeck() {
+  const length = parseFloat(document.getElementById('length').value);
+  const width = parseFloat(document.getElementById('width').value);
+  const boardWidth = parseFloat(document.getElementById('boardWidth').value);
+  const boardLength = parseFloat(document.getElementById('boardLength').value);
+  const waste = parseFloat(document.getElementById('waste').value) || 0;
+
+  if ([length, width, boardWidth, boardLength].some(isNaN)) {
+    return;
+  }
+
+  const deckArea = length * width;
+  const boardArea = (boardWidth / 12) * boardLength;
+  const totalBoards = Math.ceil((deckArea / boardArea) * (1 + waste / 100));
+
+  const results = document.getElementById('calcResults');
+  results.innerHTML =
+    `Deck Area: ${deckArea.toFixed(2)} sq ft<br>` +
+    `Board Coverage: ${boardArea.toFixed(2)} sq ft per board<br>` +
+    `Boards Needed: ${totalBoards}`;
+
+  // Optional server-side calculation
+  fetch('/calculate-deck', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ length, width, boardWidth, boardLength, waste })
+  })
+    .then(r => (r.ok ? r.json() : null))
+    .then(data => {
+      if (data) {
+        results.innerHTML =
+          `Deck Area: ${data.deckArea} sq ft<br>` +
+          `Board Coverage: ${data.boardArea} sq ft per board<br>` +
+          `Boards Needed: ${data.boards}`;
+      }
+    })
+    .catch(() => {});
+
+  drawDeck(length, width, boardWidth, document.getElementById('showBoards').checked);
+}
+
+function drawDeck(length, width, boardWidth, showBoards) {
+  const canvas = document.getElementById('deckCanvas');
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const scale = Math.min(canvas.width / length, canvas.height / width);
+  const deckLen = length * scale;
+  const deckWid = width * scale;
+  const offsetX = (canvas.width - deckLen) / 2;
+  const offsetY = (canvas.height - deckWid) / 2;
+
+  ctx.fillStyle = '#cfe2ff';
+  ctx.fillRect(offsetX, offsetY, deckLen, deckWid);
+  ctx.strokeStyle = '#000';
+  ctx.strokeRect(offsetX, offsetY, deckLen, deckWid);
+
+  ctx.fillStyle = '#000';
+  ctx.font = '12px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText(`${length} ft`, offsetX + deckLen / 2, offsetY - 5);
+  ctx.save();
+  ctx.translate(offsetX - 5, offsetY + deckWid / 2);
+  ctx.rotate(-Math.PI / 2);
+  ctx.fillText(`${width} ft`, 0, 0);
+  ctx.restore();
+
+  if (showBoards) {
+    ctx.strokeStyle = '#666';
+    const gap = (boardWidth / 12) * scale;
+    for (let x = offsetX + gap; x < offsetX + deckLen; x += gap) {
+      ctx.beginPath();
+      ctx.moveTo(x, offsetY);
+      ctx.lineTo(x, offsetY + deckWid);
+      ctx.stroke();
+    }
+  }
+}

--- a/server.cjs
+++ b/server.cjs
@@ -15,6 +15,7 @@ const digitalizeController = require('./controllers/digitalizeController');
 const measurementRoutes = require('./routes/measurements');
 const shapeController = require('./controllers/shapeController'); // ✅ NEW
 const uploadDrawingRoutes = require('./routes/uploadDrawing');
+const deckCalcRoutes = require('./routes/deckCalc');
 
 const app = express();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -36,25 +37,18 @@ app.post(
   digitalizeController.digitalizeDrawing
 );
 
- codex/generate-frontend-upload-form-with-preview
-app.use('/upload-drawing', uploadDrawingRoutes);
-
-app.use('/upload-measurements', measurementRoutes);
-=======
+// Upload routes
 app.use('/upload-drawing', upload.single('image'), uploadDrawingRoutes);
 
-app.use(
-  '/upload-measurements',
-  upload.single('image'),
-  measurementRoutes
-);
- main
+app.use('/upload-measurements', measurementRoutes);
 
 // ✅ NEW: handle shape area calculations
 app.post(
   '/calculate-multi-shape',
   shapeController.calculateMultiShape
 );
+
+app.use('/calculate-deck', deckCalcRoutes);
 
 // Serve frontend files and uploads
 app.use(express.static(path.join(__dirname)));

--- a/style.css
+++ b/style.css
@@ -65,6 +65,15 @@ body {
   margin: 20px auto;
 }
 
+#deckCalc {
+  max-width: 600px;
+  margin: 20px auto;
+}
+
+#deckCalc canvas {
+  background-color: var(--chat-bg);
+}
+
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(5px); }
   to { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Summary
- fix server route cleanup
- add deck layout & material calculator UI
- calculate deck boards on the client with optional server call
- draw deck layout on canvas
- expose `/calculate-deck` API endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d222c7a4c8332975aa614d42867ad

## Summary by Sourcery

Add an interactive deck layout and material calculator with client-side computation, canvas visualization, and a new server API endpoint.

New Features:
- Introduce a deck calculator form that computes deck area, board coverage, and required board count on submit
- Render deck layout on a canvas with an optional board line overlay toggled by a checkbox
- Expose a "/calculate-deck" POST endpoint for server-side deck calculations

Enhancements:
- Refactor Express route registrations to remove redundant middleware
- Add CSS styling for the deck calculator container and canvas background