### PR TITLE
Add measurement backup utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Run the test suite with:
 ```bash
 npm test
 ```
+## Backup\nRun `npm run backup` to export saved measurements to measurement_backup.json.

--- a/controllers/measurementController.js
+++ b/controllers/measurementController.js
@@ -2,6 +2,7 @@ const Tesseract = require('tesseract.js');
 const { polygonArea, calculatePerimeter, deckAreaExplanation } = require('../utils/geometry');
 const { extractNumbers } = require('../utils/extract');
 const logger = require('../utils/logger');
+const memory = require('../memory');
 
 async function uploadMeasurements(req, res) {
   try {
@@ -65,6 +66,15 @@ async function uploadMeasurements(req, res) {
     const explanation = deckAreaExplanation({
       hasCutout: poolArea > 0,
       hasMultipleShapes: poolArea > 0
+    });
+
+    memory.addMeasurement({
+      numbers,
+      outerDeckArea: outerArea,
+      poolArea,
+      usableDeckArea,
+      railingFootage,
+      fasciaBoardLength
     });
 
     res.json({

--- a/memory.js
+++ b/memory.js
@@ -27,6 +27,12 @@ function addMeasurement(data) {
   stmt.run(JSON.stringify(data), Date.now());
 }
 
+function getAllMeasurements() {
+  const stmt = db.prepare('SELECT id, data, timestamp FROM measurements ORDER BY id');
+  const rows = stmt.all();
+  return rows.map(r => ({ id: r.id, data: JSON.parse(r.data), timestamp: r.timestamp }));
+}
+
 function getRecentMessages(limit = 10) {
   const stmt = db.prepare('SELECT role, content, timestamp FROM messages ORDER BY id DESC LIMIT ?');
   const rows = stmt.all(limit);
@@ -37,4 +43,10 @@ function clearMemory() {
   db.exec('DELETE FROM messages; DELETE FROM measurements;');
 }
 
-module.exports = { addMessage, addMeasurement, getRecentMessages, clearMemory };
+module.exports = {
+  addMessage,
+  addMeasurement,
+  getRecentMessages,
+  getAllMeasurements,
+  clearMemory
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "commonjs",
   "scripts": {
     "start": "node index.js",
-    "test": "jest"
+    "test": "jest",
+    "backup": "node scripts/backupMeasurements.js"
   },
   "dependencies": {
     "better-sqlite3": "^11.10.0",

--- a/scripts/backupMeasurements.js
+++ b/scripts/backupMeasurements.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+const memory = require('../memory');
+
+const data = memory.getAllMeasurements();
+const outPath = path.join(__dirname, '..', 'measurement_backup.json');
+fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+console.log(`Backup written to ${outPath}`);


### PR DESCRIPTION
## Summary
- keep track of uploaded measurements in `memory.js`
- allow retrieving all measurements for archiving
- save measurement results during `uploadMeasurements`
- add simple backup script and npm command
- document backup step in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d2db90c148332b3029ea19dca0884