### PR TITLE
Add skirting estimation endpoint

### DIFF
--- a/__tests__/skirting.test.js
+++ b/__tests__/skirting.test.js
@@ -1,0 +1,29 @@
+const request = require('supertest');
+
+jest.mock('openai', () => {
+  return jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: jest.fn().mockResolvedValue({ choices: [{ message: { content: 'mocked' } }] }) } }
+  }));
+});
+
+const { app } = require('../server.cjs');
+
+describe('skirting endpoint', () => {
+  test('/calculate-skirting basic', async () => {
+    const res = await request(app)
+      .post('/calculate-skirting')
+      .send({
+        lengthFt: 10,
+        widthFt: 8,
+        heightFt: 2,
+        sides: 4,
+        material: 'Composite'
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.perimeter).toBe("36' 0\"");
+    expect(res.body.skirtingArea).toBe('72.00');
+    expect(res.body.panelsNeeded).toBe(3);
+    expect(res.body.material).toBe('Composite');
+    expect(res.body.note).toMatch(/durable/);
+  });
+});

--- a/controllers/skirtingController.js
+++ b/controllers/skirtingController.js
@@ -1,0 +1,63 @@
+function toFeetDecimal(feet, inches) {
+  return parseFloat(feet) + parseFloat(inches || 0) / 12;
+}
+
+function ftIn(val) {
+  const ft = Math.floor(val);
+  const inches = Math.round((val - ft) * 12);
+  return `${ft}' ${inches}"`;
+}
+
+function calculateSkirting(req, res) {
+  const {
+    lengthFt,
+    lengthIn = 0,
+    widthFt,
+    widthIn = 0,
+    heightFt,
+    heightIn = 0,
+    sides = 4,
+    material
+  } = req.body;
+
+  if (
+    lengthFt == null ||
+    widthFt == null ||
+    heightFt == null ||
+    !material ||
+    ![3, 4].includes(Number(sides))
+  ) {
+    return res.status(400).json({
+      errors: [{ msg: 'lengthFt, widthFt, heightFt, sides (3 or 4) and material are required' }]
+    });
+  }
+
+  const length = toFeetDecimal(lengthFt, lengthIn);
+  const width = toFeetDecimal(widthFt, widthIn);
+  const height = toFeetDecimal(heightFt, heightIn);
+
+  const perimeter =
+    Number(sides) === 4 ? 2 * (length + width) : 2 * width + length;
+  const skirtingArea = perimeter * height;
+  const panelsNeeded = Math.ceil(skirtingArea / 32);
+
+  let note = '';
+  if (material === 'Composite') {
+    note = 'Composite skirting is durable but heavier — framing may be required.';
+  } else if (material === 'PVC') {
+    note = 'PVC skirting is lightweight and rot-proof, ideal for wet areas.';
+  } else if (material === 'Mineral Board') {
+    note = 'Mineral Board is highly fire- and insect-resistant, great for premium projects.';
+  }
+
+  res.json({
+    perimeter: ftIn(perimeter),
+    skirtingArea: skirtingArea.toFixed(2),
+    panelsNeeded,
+    material,
+    tip: 'Always round up and order 1–2 extra panels for cutting and waste.',
+    note
+  });
+}
+
+module.exports = { calculateSkirting };

--- a/routes/skirting.js
+++ b/routes/skirting.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { calculateSkirting } = require('../controllers/skirtingController');
+
+const router = express.Router();
+
+router.post('/', calculateSkirting);
+
+module.exports = router;

--- a/server.cjs
+++ b/server.cjs
@@ -16,6 +16,7 @@ const measurementRoutes = require('./routes/measurements');
 const shapeController = require('./controllers/shapeController'); // ✅ NEW
 const uploadDrawingRoutes = require('./routes/uploadDrawing');
 const deckCalcRoutes = require('./routes/deckCalc');
+const skirtingRoutes = require('./routes/skirting');
 
 const app = express();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -49,6 +50,7 @@ app.post(
 );
 
 app.use('/calculate-deck', deckCalcRoutes);
+app.use('/calculate-skirting', skirtingRoutes);
 
 // Serve frontend files and uploads
 app.use(express.static(path.join(__dirname)));

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -5,7 +5,7 @@ const config = require('../config');
 
 const logDir = path.join(__dirname, '..', 'logs');
 if (!fs.existsSync(logDir)) {
-  fs.mkdirSync(logDir);
+  fs.mkdirSync(logDir, { recursive: true });
 }
 
 const logger = winston.createLogger({


### PR DESCRIPTION
## Summary
- add skirting calculation controller and route
- expose `/calculate-skirting` from server
- make logger create directory recursively
- add tests for new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d36ee4eac8332930b87ef860762e9