### PR TITLE
Handle foot/inch symbols in measurement parsing

### DIFF
--- a/__tests__/extractNumbers.test.js
+++ b/__tests__/extractNumbers.test.js
@@ -16,6 +16,11 @@ describe('extractNumbers', () => {
     expect(extractNumbers(text)).toEqual([10, 12]);
   });
 
+  test('parses feet and inches', () => {
+    const text = "Height 5' 8\"";
+    expect(extractNumbers(text)).toEqual([5 + 8 / 12]);
+  });
+
   test('filters out huge misreads', () => {
     const text = 'Size 611ft';
     expect(extractNumbers(text)).toEqual([]);

--- a/__tests__/shape.test.js
+++ b/__tests__/shape.test.js
@@ -38,9 +38,23 @@ describe('geometry utilities', () => {
     expect(shapeFromMessage(msg)).toEqual({ type: 'rectangle', dimensions: { length: 5, width: 10 } });
   });
 
+  test('shapeFromMessage parses quoted dimensions', () => {
+    const msg = 'rectangle 6\' 6\" by 8\'';
+    const result = shapeFromMessage(msg);
+    expect(result).toEqual({
+      type: 'rectangle',
+      dimensions: { length: 6.5, width: 8 }
+    });
+  });
+
   test('shapeFromMessage parses circle', () => {
     const msg = 'circle radius 4';
     expect(shapeFromMessage(msg)).toEqual({ type: 'circle', dimensions: { radius: 4 } });
+  });
+
+  test('shapeFromMessage parses circle with inches', () => {
+    const msg = 'circle radius 18\"';
+    expect(shapeFromMessage(msg)).toEqual({ type: 'circle', dimensions: { radius: 1.5 } });
   });
 
   test('shapeFromMessage handles invalid input', () => {

--- a/controllers/measurementController.js
+++ b/controllers/measurementController.js
@@ -22,7 +22,8 @@ async function uploadMeasurements(req, res) {
       data: { text }
     } = await Tesseract.recognize(req.file.buffer, 'eng', {
       tessedit_pageseg_mode: 6,
-      tessedit_char_whitelist: '0123456789.',
+      // Allow foot (') and inch (") symbols in OCR results
+      tessedit_char_whitelist: "0123456789.'\"",
       logger: info => logger.debug(info)
     });
 

--- a/utils/extract.js
+++ b/utils/extract.js
@@ -1,14 +1,39 @@
+// Parse a single measurement token treating ' as feet and " as inches.
+function parseMeasurement(token) {
+  const t = token.trim();
+  let m = t.match(/^(\d+(?:\.\d+)?)\s*'\s*(\d+(?:\.\d+)?)\s*"$/); // X' Y"
+  if (m) {
+    return parseFloat(m[1]) + parseFloat(m[2]) / 12;
+  }
+  m = t.match(/^(\d+(?:\.\d+)?)\s*'$/); // X'
+  if (m) {
+    return parseFloat(m[1]);
+  }
+  m = t.match(/^(\d+(?:\.\d+)?)\s*"$/); // X"
+  if (m) {
+    return parseFloat(m[1]) / 12;
+  }
+  m = t.match(/^(\d+(?:\.\d+)?)/); // plain number
+  if (m) {
+    return parseFloat(m[1]);
+  }
+  return null;
+}
+
 function extractNumbers(rawText) {
   if (!rawText) {
     return [];
   }
-  const cleaned = rawText.replace(/["'″’]/g, '');
-  const numberPattern = /\d+(?:\.\d+)?/g;
-  const matches = cleaned.match(numberPattern);
+  // Standardize curly quotes from OCR output
+  const normalized = rawText.replace(/[’]/g, "'").replace(/[″]/g, '"');
+  const pattern = /\d+(?:\.\d+)?(?:\s*'\s*\d+(?:\.\d+)?\s*\")?|\d+(?:\.\d+)?\s*'|\d+(?:\.\d+)?\s*\"|\d+(?:\.\d+)?/g;
+  const matches = normalized.match(pattern);
   if (!matches) {
     return [];
   }
-  return matches.map(Number).filter(n => n <= 500);
+  return matches
+    .map(parseMeasurement)
+    .filter(n => typeof n === 'number' && !isNaN(n) && n <= 500);
 }
 
-module.exports = { extractNumbers };
+module.exports = { extractNumbers, parseMeasurement };

--- a/utils/geometry.js
+++ b/utils/geometry.js
@@ -44,27 +44,44 @@ function evaluateExpression(text) {
   return null;
 }
 
+const { parseMeasurement } = require('./extract');
+
 function shapeFromMessage(message) {
   const text = message.toLowerCase();
-  let m = text.match(/rectangle\s*(\d+(?:\.\d+)?)\s*(?:x|by|\*)\s*(\d+(?:\.\d+)?)/);
+
+  let m = text.match(/rectangle\s*([\d'"\.\s]+?)\s*(?:x|by|\*)\s*([\d'"\.\s]+)/);
   if (m) {
-    return { type: 'rectangle', dimensions: { length: parseFloat(m[1]), width: parseFloat(m[2]) } };
+    return {
+      type: 'rectangle',
+      dimensions: { length: parseMeasurement(m[1]), width: parseMeasurement(m[2]) }
+    };
   }
-  m = text.match(/circle.*?radius\s*(\d+(?:\.\d+)?)/);
+
+  m = text.match(/circle.*?radius\s*([\d'"\.]+)/);
   if (m) {
-    return { type: 'circle', dimensions: { radius: parseFloat(m[1]) } };
+    return { type: 'circle', dimensions: { radius: parseMeasurement(m[1]) } };
   }
-  m = text.match(/triangle\s*(\d+(?:\.\d+)?)\s*(?:x|by|\*)\s*(\d+(?:\.\d+)?)/);
+
+  m = text.match(/triangle\s*([\d'"\.\s]+)\s*(?:x|by|\*)\s*([\d'"\.\s]+)/);
   if (m) {
-    return { type: 'triangle', dimensions: { base: parseFloat(m[1]), height: parseFloat(m[2]) } };
+    return {
+      type: 'triangle',
+      dimensions: { base: parseMeasurement(m[1]), height: parseMeasurement(m[2]) }
+    };
   }
-  m = text.match(/trapezoid.*?(\d+(?:\.\d+)?).*?(\d+(?:\.\d+)?).*?height\s*(\d+(?:\.\d+)?)/);
+
+  m = text.match(/trapezoid.*?([\d'"\.]+).*?([\d'"\.]+).*?height\s*([\d'"\.]+)/);
   if (m) {
     return {
       type: 'trapezoid',
-      dimensions: { base1: parseFloat(m[1]), base2: parseFloat(m[2]), height: parseFloat(m[3]) }
+      dimensions: {
+        base1: parseMeasurement(m[1]),
+        base2: parseMeasurement(m[2]),
+        height: parseMeasurement(m[3])
+      }
     };
   }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- support `'` and `"` in measurements
- improve OCR whitelist to keep foot and inch characters
- extend shape parsing to understand quoted dimensions
- add tests for new measurement parsing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d3972f3b08332948e78b352890db9