### PR TITLE
Add skirting detection in measurement uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ npm test
 
 - [Master Prompt](docs/MASTER_PROMPT.md)
 - [Measurement Extraction Logic](docs/MEASUREMENT_EXTRACTION.md)
+- **API:** `POST /calculate-skirting` – estimate skirting materials using feet/inch measurements
+- Uploads mentioning "skirting" auto-return perimeter and panel estimates

--- a/__tests__/measurements.test.js
+++ b/__tests__/measurements.test.js
@@ -104,6 +104,17 @@ describe('server edge cases', () => {
     });
   });
 
+  test('/upload-measurements skirting detection', async () => {
+    recognizeMock.mockResolvedValue({ data: { text: "skirting 12' 10' 30\" PVC" } });
+    const res = await request(app)
+      .post('/upload-measurements')
+      .attach('image', Buffer.from('img'), 'skirt.png');
+    expect(res.status).toBe(200);
+    expect(res.body.material).toBe('PVC');
+    expect(res.body.perimeter).toBe("44' 0\"");
+    expect(res.body.panelsNeeded).toBe(4);
+  });
+
   test('/digitalize-drawing success', async () => {
     potrace.trace.mockImplementation((p, o, cb) => cb(null, '<svg/>'));
     recognizeMock.mockResolvedValue({ data: { text: '0 0 10 0 10 10' } });

--- a/__tests__/skirting.test.js
+++ b/__tests__/skirting.test.js
@@ -26,4 +26,22 @@ describe('skirting endpoint', () => {
     expect(res.body.material).toBe('Composite');
     expect(res.body.note).toMatch(/durable/);
   });
+
+  test('/calculate-skirting string inputs', async () => {
+    const res = await request(app)
+      .post('/calculate-skirting')
+      .send({
+        length: "12' 6\"",
+        width: "10'",
+        height: "30\"",
+        sides: 3,
+        material: 'PVC'
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.material).toBe('PVC');
+    expect(res.body.perimeter).toBe("32' 6\"");
+    expect(res.body.panelsNeeded).toBe(3);
+    expect(res.body.note).toMatch(/rot-proof/);
+  });
 });
+

--- a/controllers/measurementController.js
+++ b/controllers/measurementController.js
@@ -1,6 +1,7 @@
 const Tesseract = require('tesseract.js');
 const { polygonArea, calculatePerimeter, deckAreaExplanation } = require('../utils/geometry');
-const { extractNumbers } = require('../utils/extract');
+const { extractNumbers, parseMeasurement } = require('../utils/extract');
+const { calculateSkirtingMetrics, ftIn } = require('../utils/skirting');
 const logger = require('../utils/logger');
 const memory = require('../memory');
 
@@ -30,14 +31,48 @@ async function uploadMeasurements(req, res) {
     const numbers = extractNumbers(text);
     logger.info(`🔢 Extracted numbers: ${numbers.join(', ')}`);
 
+    // If image mentions skirting, run the skirting estimator
+    if (/skirting/i.test(text)) {
+      const tokens = text.replace(/[’,]/g, "'").split(/\s+/);
+      const idx = tokens.findIndex(t => /skirting/i.test(t));
+      const vals = [];
+      for (let i = idx + 1; i < tokens.length && vals.length < 3; i++) {
+        const v = parseMeasurement(tokens[i]);
+        if (typeof v === 'number' && !Number.isNaN(v)) {
+          vals.push(v);
+        }
+      }
+      if (vals.length >= 3) {
+        const material = /PVC/i.test(text)
+          ? 'PVC'
+          : /Mineral\s*Board/i.test(text) || /Mineral/i.test(text)
+            ? 'Mineral Board'
+            : 'Composite';
+        const result = calculateSkirtingMetrics({
+          length: vals[0],
+          width: vals[1],
+          height: vals[2],
+          material
+        });
+        return res.json({
+          perimeter: ftIn(result.perimeter),
+          skirtingArea: result.skirtingArea.toFixed(2),
+          panelsNeeded: result.panelsNeeded,
+          material: result.material,
+          tip: result.tip,
+          note: result.note
+        });
+      }
+    }
+
     // ✅ 2. Consistent error format for test expectations
-  if (numbers.length < 6) {
-  return res.status(400).json({
-    errors: [{
-      msg: 'Not enough coordinates detected. Please ensure your drawing is clear and numbers are legible.'
-    }]
-  });
-}
+    if (numbers.length < 6) {
+      return res.status(400).json({
+        errors: [{
+          msg: 'Not enough coordinates detected. Please ensure your drawing is clear and numbers are legible.'
+        }]
+      });
+    }
 
     const hasPool = /pool/i.test(text);
     const midpoint = hasPool ? numbers.length / 2 : numbers.length;

--- a/utils/skirting.js
+++ b/utils/skirting.js
@@ -1,0 +1,30 @@
+function ftIn(val) {
+  const ft = Math.floor(val);
+  const inches = Math.round((val - ft) * 12);
+  return `${ft}' ${inches}"`;
+}
+
+function calculateSkirtingMetrics({ length, width, height, sides = 4, material }) {
+  const perimeter = Number(sides) === 4 ? 2 * (length + width) : 2 * width + length;
+  const skirtingArea = perimeter * height;
+  const panelsNeeded = Math.ceil(skirtingArea / 32);
+  let note = '';
+  if (material === 'Composite') {
+    note = 'Composite skirting is durable but heavier — framing may be required.';
+  } else if (material === 'PVC') {
+    note = 'PVC skirting is lightweight and rot-proof, ideal for wet areas.';
+  } else if (material === 'Mineral Board') {
+    note = 'Mineral Board is highly fire- and insect-resistant, great for premium projects.';
+  }
+  return {
+    perimeter,
+    skirtingArea,
+    panelsNeeded,
+    material,
+    tip: 'Always round up and order 1–2 extra panels for cutting and waste.',
+    note
+  };
+}
+
+module.exports = { calculateSkirtingMetrics, ftIn };
+


### PR DESCRIPTION
## Summary
- extract skirting info in `uploadMeasurements`
- factor skirting math to `utils/skirting`
- reuse helper in skirting controller
- document auto-skirting estimates in README
- test skirting detection through measurement endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd1c24d9c83329504b202d36b6ec8