### PR TITLE
Fix config path and clean merge artifacts

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -3,5 +3,6 @@ require('dotenv').config();
 module.exports = {
   PORT: process.env.PORT || 3000,
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',
-  OPENAI_API_KEY: process.env.OPENAI_API_KEY || ''
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
+  MEM_DB: process.env.MEM_DB
 };

--- a/controllers/measurementController.js
+++ b/controllers/measurementController.js
@@ -33,10 +33,7 @@ async function uploadMeasurements(req, res) {
     });
 
     const numbers = extractNumbers(text);
-    logger.info(`🔢 Extracted numbers: ${numbers.join(', ')}`);
-
- feature/drawing-upload-v2
-=======
+  logger.info(`🔢 Extracted numbers: ${numbers.join(', ')}`);
     // If image mentions skirting, run the skirting estimator
     if (/skirting/i.test(text)) {
       const tokens = text.replace(/[’,]/g, "'").split(/\s+/);
@@ -71,8 +68,7 @@ async function uploadMeasurements(req, res) {
       }
     }
 
-    // ✅ 2. Consistent error format for test expectations
- main
+  // ✅ 2. Consistent error format for test expectations
     if (numbers.length < 6) {
       return res.status(400).json({
         errors: [{
@@ -111,8 +107,7 @@ async function uploadMeasurements(req, res) {
       hasMultipleShapes: poolArea > 0
     });
 
- feature/drawing-upload-v2
-    // ✅ SKIRTING LOGIC START
+  // ✅ SKIRTING LOGIC START
     const includeSkirting = /skirt|skirting/i.test(text);
     let skirting = null;
 
@@ -143,8 +138,7 @@ async function uploadMeasurements(req, res) {
         tip: 'Add 1–2 extra panels to cover waste and trimming.'
       };
     }
-    // ✅ SKIRTING LOGIC END
-=======
+  // ✅ SKIRTING LOGIC END
     memory.addMeasurement({
       numbers,
       outerDeckArea: outerArea,
@@ -153,7 +147,6 @@ async function uploadMeasurements(req, res) {
       railingFootage,
       fasciaBoardLength
     });
- main
 
     res.json({
       outerDeckArea: outerArea.toFixed(2),

--- a/memory.js
+++ b/memory.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const Database = require('better-sqlite3');
+const config = require('./config');
 
-const dbFile = process.env.MEM_DB || path.join(__dirname, 'memory.sqlite');
+const dbFile = config.MEM_DB || path.join(__dirname, 'memory.sqlite');
 const db = new Database(dbFile);
 
 db.exec(`

--- a/package.json
+++ b/package.json
@@ -2,17 +2,13 @@
   "name": "decking-chatbot",
   "version": "1.0.0",
   "description": "Decking Sales Chatbot Server",
-  "main": "server.cjs",
+  "main": "index.js",
   "type": "commonjs",
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon server.cjs",
- feature/drawing-upload-v2
-    "test": "jest"
-=======
     "test": "jest",
     "backup": "node scripts/backupMeasurements.js"
- main
   },
   "dependencies": {
     "better-sqlite3": "^11.10.0",


### PR DESCRIPTION
## Summary
- load MEM_DB from config and use in memory.js
- add MEM_DB to config
- remove leftover merge markers from measurement controller
- fix package.json scripts object
- use index.js as package main

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e9b8bd22483328e1e77f037739721

## Summary by Sourcery

Clean up merge artifacts, update configuration for the memory database, and correct package entry point and scripts

Enhancements:
- Add MEM_DB configuration option and use it in memory.js

Build:
- Set index.js as the package main entry and fix npm scripts in package.json

Chores:
- Remove leftover merge conflict markers from the measurement controller