### PR TITLE
Allow direct server.cjs run

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project provides a simple Express server with a chatbot interface for deck 
    npm install
    ```
 2. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+   You can also set `MEM_DB` to choose a custom path for the SQLite database.
 3. Start the server:
    ```bash
    npm start
@@ -31,4 +32,7 @@ Run `npm run backup` to export saved measurements to measurement_backup.json.
 ## API
 - **API:** `POST /calculate-skirting` – estimate skirting materials using feet/inch measurements
 - Uploads mentioning "skirting" auto-return perimeter and panel estimates
+
+### Direct start
+Running `node server.cjs` starts a single-process server if you prefer not to use the cluster entry point.
 

--- a/config/index.js
+++ b/config/index.js
@@ -3,5 +3,6 @@ require('dotenv').config();
 module.exports = {
   PORT: process.env.PORT || 3000,
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',
-  OPENAI_API_KEY: process.env.OPENAI_API_KEY || ''
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
+  MEM_DB: process.env.MEM_DB
 };

--- a/controllers/measurementController.js
+++ b/controllers/measurementController.js
@@ -33,10 +33,7 @@ async function uploadMeasurements(req, res) {
     });
 
     const numbers = extractNumbers(text);
-    logger.info(`🔢 Extracted numbers: ${numbers.join(', ')}`);
-
- feature/drawing-upload-v2
-=======
+  logger.info(`🔢 Extracted numbers: ${numbers.join(', ')}`);
     // If image mentions skirting, run the skirting estimator
     if (/skirting/i.test(text)) {
       const tokens = text.replace(/[’,]/g, "'").split(/\s+/);
@@ -71,8 +68,7 @@ async function uploadMeasurements(req, res) {
       }
     }
 
-    // ✅ 2. Consistent error format for test expectations
- main
+  // ✅ 2. Consistent error format for test expectations
     if (numbers.length < 6) {
       return res.status(400).json({
         errors: [{
@@ -111,8 +107,7 @@ async function uploadMeasurements(req, res) {
       hasMultipleShapes: poolArea > 0
     });
 
- feature/drawing-upload-v2
-    // ✅ SKIRTING LOGIC START
+  // ✅ SKIRTING LOGIC START
     const includeSkirting = /skirt|skirting/i.test(text);
     let skirting = null;
 
@@ -143,8 +138,7 @@ async function uploadMeasurements(req, res) {
         tip: 'Add 1–2 extra panels to cover waste and trimming.'
       };
     }
-    // ✅ SKIRTING LOGIC END
-=======
+  // ✅ SKIRTING LOGIC END
     memory.addMeasurement({
       numbers,
       outerDeckArea: outerArea,
@@ -153,7 +147,6 @@ async function uploadMeasurements(req, res) {
       railingFootage,
       fasciaBoardLength
     });
- main
 
     res.json({
       outerDeckArea: outerArea.toFixed(2),

--- a/memory.js
+++ b/memory.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const Database = require('better-sqlite3');
+const config = require('./config');
 
-const dbFile = process.env.MEM_DB || path.join(__dirname, 'memory.sqlite');
+const dbFile = config.MEM_DB || path.join(__dirname, 'memory.sqlite');
 const db = new Database(dbFile);
 
 db.exec(`

--- a/package.json
+++ b/package.json
@@ -2,17 +2,13 @@
   "name": "decking-chatbot",
   "version": "1.0.0",
   "description": "Decking Sales Chatbot Server",
-  "main": "server.cjs",
+  "main": "index.js",
   "type": "commonjs",
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon server.cjs",
- feature/drawing-upload-v2
-    "test": "jest"
-=======
     "test": "jest",
     "backup": "node scripts/backupMeasurements.js"
- main
   },
   "dependencies": {
     "better-sqlite3": "^11.10.0",

--- a/server.cjs
+++ b/server.cjs
@@ -69,3 +69,12 @@ app.use((err, req, res, next) => {
 
 // Export for index.js (clustered start)
 module.exports = { app, logger };
+
+// Allow running `node server.cjs` directly for a single-process server
+if (require.main === module) {
+  const config = require('./config');
+  const PORT = config.PORT || 3000;
+  app.listen(PORT, () => {
+    logger.info(`✅ Server running at http://localhost:${PORT}`);
+  });
+}


### PR DESCRIPTION
## Summary
- let server.cjs start the server when run directly
- document MEM_DB and single-process start option

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e9b8bd22483328e1e77f037739721

## Summary by Sourcery

Enable single-process server start via server.cjs, support a configurable MEM_DB path, clean up merge artifacts, and update project config and documentation accordingly.

New Features:
- Allow `node server.cjs` to start a single-process server entry point.
- Add `MEM_DB` environment variable to specify a custom path for the SQLite database.

Enhancements:
- Remove leftover merge conflict markers and correct logging placement in measurementController.js.
- Restore package.json main entry to index.js.

Documentation:
- Document the `MEM_DB` option and direct `server.cjs` startup in README.

Chores:
- Expose `MEM_DB` in config and refactor memory.js to use config.MEM_DB.