### PR TITLE
Add setup troubleshooting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Run `npm run backup` to export saved measurements to measurement_backup.json.
 - [Master Prompt](docs/MASTER_PROMPT.md)
 - [Measurement Extraction Logic](docs/MEASUREMENT_EXTRACTION.md)
 - [File Upload Troubleshooting](docs/FILE_UPLOAD_TROUBLESHOOTING.md)
+- [Setup Troubleshooting](docs/SETUP_TROUBLESHOOTING.md)
 ## API
 - **API:** `POST /calculate-skirting` – estimate skirting materials using feet/inch measurements
 - Uploads mentioning "skirting" auto-return perimeter and panel estimates

--- a/docs/SETUP_TROUBLESHOOTING.md
+++ b/docs/SETUP_TROUBLESHOOTING.md
@@ -1,0 +1,20 @@
+# Setup Troubleshooting
+
+This guide addresses common issues when starting the Deck Chatbot locally.
+
+## 1. Missing or Misnamed Database File
+If the server logs show an error such as:
+```
+Error: Cannot open file ./sqlite.json
+```
+ensure the expected JSON or SQLite file exists. This project normally uses `deckchatbot.db`. If you see the above message, check that your database file name matches the path used in your start command. Rename or create the file if needed.
+
+## 2. Local Domain Configuration
+The app listens on port 3000 by default. Browsing to a custom domain like `deckchatbot.local` requires mapping that name to `127.0.0.1` in your hosts file and including the port number:
+```
+http://deckchatbot.local:3000
+```
+If you use Localtunnel, open the URL printed in the terminal, typically `https://<subdomain>.loca.lt`.
+
+Fixing the file path and using the correct host address should resolve blank pages or startup errors.
+


### PR DESCRIPTION
## Summary
- document common startup problems in `docs/SETUP_TROUBLESHOOTING.md`
- reference the troubleshooting guide in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f1a29d9ec833298b587dca5034105

## Summary by Sourcery

Add a troubleshooting guide for local setup issues and link it in the README

Documentation:
- Provide a new `docs/SETUP_TROUBLESHOOTING.md` outlining common startup problems
- Reference the setup troubleshooting guide in the project README